### PR TITLE
Fix issues with inline assembly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "thumbv8m.main-none-eabihf" # Cortex-M33
+target = "thumbv6m-none-eabi" # Cortex-M0+


### PR DESCRIPTION
* Fix compilation for thumbv6m-none-eabi / cortex-m0 by using `adds` for `stack_painted`.
* Fix UB inline assembly in `repaint_stack` in which the invariance requirement for `stack().end` was violated. Fixed by using `inout` instead of `in`.
* Define `#[inline(never)]` for `stack_painted` such that it is always checked at build-time.